### PR TITLE
Fixed crash when asking network context to remove observer of all lights collections

### DIFF
--- a/LIFXKit/Classes/LFXLightCollection.m
+++ b/LIFXKit/Classes/LFXLightCollection.m
@@ -146,7 +146,7 @@
 
 - (void)removeLightCollectionObserver:(id <LFXLightCollectionObserver>)observer
 {
-	[self.lightCollectionObserverProxy addObserver:observer];
+	[self.lightCollectionObserverProxy removeObserver:observer];
 }
 
 #pragma mark - LFXLightObserver


### PR DESCRIPTION
the light collection instead of removing it would add it back as an observer, when you do this on a deallocated object it would crash
