### PR TITLE
Fix crash on unhandled StateService payload

### DIFF
--- a/LIFXKit/Classes-Common/LFXGatewayConnection.m
+++ b/LIFXKit/Classes-Common/LFXGatewayConnection.m
@@ -32,6 +32,8 @@
 			return [[LFXTCPGatewayConnection alloc] initWithGatewayDescriptor:gateway messageRateManager:messageRateManager delegate:delegate];
 		case LX_PROTOCOL_DEVICE_SERVICE_UDP:
 			return [[LFXUDPGatewayConnection alloc] initWithGatewayDescriptor:gateway messageRateManager:messageRateManager delegate:delegate];
+		default:
+			return nil;
 	}
 }
 

--- a/LIFXKit/Classes-Common/LFXLocalTransportManager.m
+++ b/LIFXKit/Classes-Common/LFXLocalTransportManager.m
@@ -347,6 +347,9 @@
 		
 		LFXLogInfo(@"Service %@/%@:%u has no existing connection, connecting", gateway.protocolString, gateway.host, gateway.port);
 		LFXGatewayConnection *newConnection = [LFXGatewayConnection gatewayConnectionWithGatewayDescriptor:gateway messageRateManager:self.networkContext.messageRateManager delegate:self];
+		if (!newConnection) {
+			return;
+		}
 		self.gatewayConnections[gateway] = newConnection;
 		[newConnection connect];
 		[self connectionStatesDidChange];


### PR DESCRIPTION
Not returning from an `instancetype` method is undefined behaviour, and in this instance it's returning a garbage pointer, resulting in "does not respond to selector" errors on random objects, and causing a crash. `-Wswitch` does not raise a warning because the all the possible values of the enum are handled.

The solution is to explicitly return `nil` if no match is found, and bail out if the return value of `+LFXGatewayConnection gatewayConnectionWithGatewayDescriptor` returns nil.

Closes #24.