### PR TITLE
Suppress auto property synthesis override warnings

### DIFF
--- a/LIFXKit/Classes-Common/LXProtocolMessages.h
+++ b/LIFXKit/Classes-Common/LXProtocolMessages.h
@@ -9,6 +9,9 @@
 
 typedef LXProtocolType LFXMessageType;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-property-synthesis"
+
 //===========================================================================
 
 
@@ -891,3 +894,4 @@ typedef LXProtocolType LFXMessageType;
 
 //===========================================================================
 
+#pragma clang diagnostic pop


### PR DESCRIPTION
```
Auto property synthesis will not synthesize property '***'; it will be implemented by its superclass, use @dynamic to acknowledge intention
```

Rather than add that to every single class definition, just suppress that specific warning for this file.
